### PR TITLE
Upgrade to libdns v1.1.0 with full API compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.claude/settings.local.json

--- a/_example/main.go
+++ b/_example/main.go
@@ -32,9 +32,13 @@ func main() {
 	testName := "libdns-test"
 	testID := ""
 	for _, record := range records {
-		fmt.Printf("%s (.%s): %s, %s\n", record.Name, zone, record.Value, record.Type)
-		if record.Name == testName {
-			testID = record.ID
+		rr := record.RR()
+		fmt.Printf("%s (.%s): %s, %s\n", rr.Name, zone, rr.Data, rr.Type)
+		if rr.Name == testName {
+			// Extract ID from our custom record type
+			if rwid, ok := record.(*dnspod.RecordWithID); ok {
+				testID = rwid.GetID()
+			}
 		}
 
 	}
@@ -49,23 +53,27 @@ func main() {
 		// }
 		// Set only works if we have a record.ID
 		fmt.Printf("Replacing entry for %s\n", testName)
-		_, err = provider.SetRecords(context.TODO(), zone, []libdns.Record{libdns.Record{
-			Type:  "TXT",
-			Name:  testName,
-			Value: fmt.Sprintf("Replacement test entry created by libdns %s", time.Now()),
-			TTL:   time.Duration(600) * time.Second,
-			ID:    testID,
+		_, err = provider.SetRecords(context.TODO(), zone, []libdns.Record{&dnspod.RecordWithID{
+			ResourceRecord: libdns.RR{
+				Type: "TXT",
+				Name: testName,
+				Data: fmt.Sprintf("Replacement test entry created by libdns %s", time.Now()),
+				TTL:  time.Duration(600) * time.Second,
+			},
+			ID: testID,
 		}})
 		if err != nil {
 			fmt.Printf("ERROR: %s\n", err.Error())
 		}
 	} else {
 		fmt.Printf("Creating new entry for %s\n", testName)
-		_, err = provider.AppendRecords(context.TODO(), zone, []libdns.Record{libdns.Record{
-			Type:  "TXT",
-			Name:  testName,
-			Value: fmt.Sprintf("This is a test entry created by libdns %s", time.Now()),
-			TTL:   time.Duration(600) * time.Second,
+		_, err = provider.AppendRecords(context.TODO(), zone, []libdns.Record{&dnspod.RecordWithID{
+			ResourceRecord: libdns.RR{
+				Type: "TXT",
+				Name: testName,
+				Data: fmt.Sprintf("This is a test entry created by libdns %s", time.Now()),
+				TTL:  time.Duration(600) * time.Second,
+			},
 		}})
 		if err != nil {
 			fmt.Printf("ERROR: %s\n", err.Error())

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/libdns/dnspod
 go 1.14
 
 require (
-	github.com/libdns/libdns v0.2.1
+	github.com/libdns/libdns v1.1.0
 	github.com/nrdcg/dnspod-go v0.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
-github.com/libdns/libdns v0.0.0-20200501023120-186724ffc821 h1:663opx/RKxiISi1ozf0WbvweQpYBgf34dx8hKSIau3w=
-github.com/libdns/libdns v0.0.0-20200501023120-186724ffc821/go.mod h1:yQCXzk1lEZmmCPa857bnk4TsOiqYasqpyOEeSObbb40=
-github.com/libdns/libdns v0.2.1 h1:Wu59T7wSHRgtA0cfxC+n1c/e+O3upJGWytknkmFEDis=
-github.com/libdns/libdns v0.2.1/go.mod h1:yQCXzk1lEZmmCPa857bnk4TsOiqYasqpyOEeSObbb40=
+github.com/libdns/libdns v1.1.0 h1:9ze/tWvt7Df6sbhOJRB8jT33GHEHpEQXdtkE3hPthbU=
+github.com/libdns/libdns v1.1.0/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
 github.com/nrdcg/dnspod-go v0.4.0 h1:c/jn1mLZNKF3/osJ6mz3QPxTudvPArXTjpkmYj0uK6U=
 github.com/nrdcg/dnspod-go v0.4.0/go.mod h1:vZSoFSFeQVm2gWLMkyX61LZ8HI3BaqtHZWgPTGKr6KQ=

--- a/provider.go
+++ b/provider.go
@@ -2,7 +2,6 @@ package dnspod
 
 import (
 	"context"
-	"time"
 
 	"github.com/libdns/libdns"
 )
@@ -33,7 +32,6 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 		if err != nil {
 			return nil, err
 		}
-		newRecord.TTL = time.Duration(newRecord.TTL) * time.Second
 		appendedRecords = append(appendedRecords, newRecord)
 	}
 
@@ -49,7 +47,6 @@ func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []lib
 		if err != nil {
 			return nil, err
 		}
-		deletedRecord.TTL = time.Duration(deletedRecord.TTL) * time.Second
 		deletedRecords = append(deletedRecords, deletedRecord)
 	}
 
@@ -68,7 +65,6 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 		if err != nil {
 			return setRecords, err
 		}
-		setRecord.TTL = time.Duration(setRecord.TTL) * time.Second
 		setRecords = append(setRecords, setRecord)
 	}
 


### PR DESCRIPTION
- Update go.mod to use libdns v1.1.0
- Implement RecordWithID type to handle DNSPod record IDs with new libdns.Record interface
- Replace deprecated Record fields (Value->Data, remove ID field)
- Update all provider methods to use record.RR() interface
- Fix example code to work with new API structure
- Remove unused TTL duration conversions from provider methods
- Maintain backward compatibility for DNSPod-specific functionality

🤖 Generated with [Claude Code](https://claude.ai/code)